### PR TITLE
feat: create a docker image for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,9 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
+# jetbrains IDE files
+.idea
+
 # Eleventy site
 _site/
 docs/**/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# this image is for use during documentation development only and must not be used in production
+
+FROM node:22-alpine
+
+# env var which tells our eleventy compute custom code not to attempt to create
+# metadata about each published file, just use some sensible defaults. This avoids
+# needing to install git, have a git repo available, and avoids needing some json
+# meta files which are normally created during the standard site build process.
+ENV SKIP_META=true
+
+EXPOSE 8080
+
+WORKDIR /site
+
+COPY package.json .
+# ignore scripts to avoid running the prepare script
+RUN npm i --ignore-scripts
+
+COPY src src
+COPY .eleventyignore .
+COPY eleventy.config.js .
+
+RUN mkdir docs
+COPY docs/_includes docs/_includes
+COPY docs/assets docs/assets
+COPY docs/*.njk docs/
+COPY docs/*.md docs/
+
+CMD ["npx", "eleventy", "--serve", "--watch"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,32 @@ Welcome to the UKHSA organisational standards. This repository contains standard
 
 // TODO: Add more detail on when to use these guidelines
 
+## Development container image
+
+A container image for developing documentation is defined in this repository in the `Dockerfile`.
+This image is designed to only be used in the development environment as an aid for creating documentation so that it can be previewed before adding it to this repository's configuration for publication.
+This also means documentation owners don't need to clone and use this repository to view their documentation, they can just use the image.
+
+To build the image from the root of this repository:
+
+```bash
+docker build . -t ghrc.io/ukhsa-collaboration/standards-org
+```
+
+At present, there is only a `latest` tag for this image.
+
+Using the image is detailed in the [standards-template](https://github.com/ukhsa-collaboration/standards-template) repository, however, for convenience here is the basic usage command:
+
+```bash
+docker run -p "8080:8080" -v "./docs:/site/docs/<name>" ghrc.io/ukhsa-collaboration/standards-org
+```
+
+where `<name>` is the path you wish the docs to be made available under when viewing them.
+This `<name>` must match the name of the `<name>.11tydata.json` data file in the documentation repo's docs/ dir.
+It's recommended that you use the real path (e.g. `api-design-guidelines`) you will be publishing the docs under on the standards org site as this means you can check everything will work when published, e.g. relative links.
+
+When running the above `docker run ...` command, this runs Eleventy with the `--watch`, enabling you to just run the command once and any updates will be picked up automatically.
+
 ## Contributing
 
 We welcome contributions to improve these guidelines. Please read our [Contributing Guidelines](CONTRIBUTING.md) for details on how to get involved.

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,7 @@ const md = new markdownit();
 
 /**
  * Extract text content from a Markdown AST node.
- * 
+ *
  * @param {*} node - The AST node to extract text from.
  * @returns {string} - The extracted text content.
  */
@@ -201,7 +201,7 @@ export const getPageGitUpdatedDate = async (data) => {
 
 /**
  * Get the default navigation title for a page.
- * 
+ *
  * @param {*} data - The page data.
  * @returns {string|null} - The default navigation title or null.
  */
@@ -271,11 +271,21 @@ export const getDefaultNavigationParent = data => {
 
 /**
  * Get the metadata for a page from the docs meta file.
- * 
+ *
  * @param {*} page - The page object.
  * @returns {Promise<Object|null>} - The metadata for the page or null if not found.
  */
 async function getDocMetaForPage(page) {
+  if ('SKIP_META' in process.env) {
+    // skip creating the real metadata about a page, just use some sensible defaults
+    const now = new Date();
+    return {
+      created: now,
+      lastUpdated: now,
+      permalink: page.inputPath
+    }
+  }
+
   const dirName = path.dirname(page.filePathStem);
   const parentFolder = dirName === "/" ? "home" : page.filePathStem.split(path.sep)[1];
 
@@ -288,8 +298,8 @@ async function getDocMetaForPage(page) {
   }
 
   if (!docsMeta[parentFolder]) {
-    const { default: meta } =
-      await import(`../docs/${parentFolder}/${parentFolder}-meta.json`, { with: { type: "json" } });
+    const {default: meta} =
+      await import(`../docs/${parentFolder}/${parentFolder}-meta.json`, {with: {type: "json"}});
     docsMeta[parentFolder] = meta;
   }
 


### PR DESCRIPTION
This PR adds a docker image for local publishing to enable teams to test their documentation locally before it is included in this repository. See README updates for details about how to use this.

*Draft status at the moment as I haven't added an action to build the image yet*