### PR TITLE
feat: add a placeholder page for Ways of Working until the repo is ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ docs/**/*
 !docs/_includes/**
 !docs/assets/**
 !docs/*
+
+# temporarily allow this until we add a proper standards-wow repo
+!docs/wow/*

--- a/docs/wow/index.md
+++ b/docs/wow/index.md
@@ -1,0 +1,9 @@
+---
+# this is a placeholder until we get a wow repo setup and ready to publish so that when users follow the WoW link from
+# the homepage, they don't just hit a 404
+---
+# Introduction
+
+Guidance on how teams should work together, including collaboration, communication, and project management practices.
+
+Coming soon...

--- a/docs/wow/wow-meta.json
+++ b/docs/wow/wow-meta.json
@@ -1,0 +1,13 @@
+{
+  "./docs/wow/index.md": {
+    "file": "./docs/wow/index.md",
+    "permalink": "https://github.com/ukhsa-collaboration/standards-org/blob/main/docs/wow/index.md",
+    "created": "2025-09-12T10:55:11+01:00",
+    "createdBy": "Josh Humphries",
+    "lastUpdated": "2025-09-12T10:55:11+01:00",
+    "lastUpdatedBy": "Josh Humphries",
+    "contributors": [
+      "Josh Humphries"
+    ]
+  }
+}

--- a/docs/wow/wow.11tydata.json
+++ b/docs/wow/wow.11tydata.json
@@ -1,0 +1,4 @@
+{
+  "layout": "sub-navigation",
+  "caption": "Ways of Working"
+}


### PR DESCRIPTION
There's no repo yet and the doc isn't complete but we still have a link to WoW documentation from the home page. Instead of just removing it from the homepage, it feels better to add a placeholder page until it's ready.

We'll have to make sure that when we add the WoW configuration properly, we remove the ./docs/wow dir and remove the temp .gitignore entry.