### PR TITLE
build: allow qat and tech-radar repos to trigger publish workflow

### DIFF
--- a/.github/workflows/publish-guidelines.yml
+++ b/.github/workflows/publish-guidelines.yml
@@ -11,6 +11,8 @@ on:
           - ukhsa-collaboration/standards-org
           - ukhsa-collaboration/standards-api
           - ukhsa-collaboration/standards-development
+          - ukhsa-collaboration/standards-tech-radar
+          - ukhsa-collaboration/standards-qat
       upstream_sha:
         description: Commit SHA in the triggering repository
         type: string


### PR DESCRIPTION
Just merged https://github.com/ukhsa-collaboration/standards-tech-radar/pull/29 and it [failed](https://github.com/ukhsa-collaboration/standards-tech-radar/actions/runs/28933518428/job/85838140655) to trigger the publish workflow because it's not listed in the allowed options. Added QAT too while I was there.